### PR TITLE
ensure a non-nil error message for invalid emails and phone numbers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 
 ## CHANGES
 
+  * Ensure a non-nil error message for invalid emails and phone numbers
 
 # 3.3.0
 

--- a/lib/active_validators/active_model/validations/email_validator.rb
+++ b/lib/active_validators/active_model/validations/email_validator.rb
@@ -16,12 +16,12 @@ module ActiveModel
         end
 
         if options[:with]
-          # technically the test suite will pass without the boolean coercion 
+          # technically the test suite will pass without the boolean coercion
           # but we know the code is safer with it in place
           valid &&= !!options[:with].call(mail)
         end
 
-        record.errors.add attribute, (options[:message]) unless valid
+        record.errors.add attribute, (options.fetch(:message, :invalid)) unless valid
       end
 
       def basic_check(mail)

--- a/lib/active_validators/active_model/validations/phone_validator.rb
+++ b/lib/active_validators/active_model/validations/phone_validator.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class PhoneValidator < EachValidator
       def validate_each(record, attribute, value)
         country_code = Country.new(options[:country].to_s.upcase).country_code unless options[:country].blank?
-        record.errors.add(attribute, options[:message]) if value.blank? || ! (options[:country].blank? ? Phony.plausible?(value) : Phony.plausible?(value, :cc => country_code) )
+        record.errors.add(attribute, options.fetch(:message, :invalid)) if value.blank? || ! (options[:country].blank? ? Phony.plausible?(value) : Phony.plausible?(value, :cc => country_code) )
       end
 
     end


### PR DESCRIPTION
I found that I needed to add this because my email validity tests were
failing without it. using shoulda-matchers, I wrote the following test
with rspec:

```
it { is_expected.not_to allow_value('foo').for(:contact_email) }
```

the test failed when shoulda-matchers raised a TypeError with message
`can't dup NilClass`. tracing this I found that after calling `valid?`
on my record, the AM::Errors object had this error:

```
:contact_email => [
 [0] nil
]
```

for some reason passing a nil message to AM:Errors#add was not resulting
in the default `:invalid` message. this patch, however, makes things
work as expected.

it's not clear to me why the invalid error message test in this library
passed before. but it's still passing now, and my application works as
expected.
